### PR TITLE
Fix incorrect rendering of namespace names

### DIFF
--- a/modules/WebTool.php
+++ b/modules/WebTool.php
@@ -8,7 +8,7 @@ DEFINE('XTOOLS_BASE_SYS_DIR_DB', '/data/project/xtools' );
 DEFINE('XTOOLS_BASE_SYS_DIR_SESSION', '/data/project/xtools' );
 DEFINE('XTOOLS_BASE_WEB_DIR', 'tools.wmflabs.org/xtools' );
 DEFINE('XTOOLS_I18_TEXTFILE', '/data/project/xtools/modules/Xtools.i18n.php'); 
-DEFINE('XTOOLS_REDIS_FLUSH_TOKEN', 'x000004');
+DEFINE('XTOOLS_REDIS_FLUSH_TOKEN', 'x000005');
 DEFINE('XTOOLS_LONG_QUEUE_COUNT', 'longQueueCount');
 DEFINE('XTOOLS_DATABASE_TMP', 's51187__xtools_tmp');
 DEFINE('XTOOLS_LONG_QUEUE_LIMIT', 6 );
@@ -354,9 +354,9 @@ class WebTool {
             'format' => 'json',
             'siprop' => 'namespaces',
          );
-         
-         $res = json_decode( $this->gethttp( "http://$domain/w/api.php?" . http_build_query( $data ) ) )->query->namespaces;
-         
+
+         $res = json_decode( $this->gethttp( "https://$domain/w/api.php?" . http_build_query( $data ) ) )->query->namespaces;
+
          foreach( $res as $id => $ns ) {
             $nsname = ( $ns->{'*'} == "" ) ? $I18N->msg('mainspace') : $ns->{'*'};
             $tmpNamespaces['ids'][$nsname] = $id;

--- a/public_html/ec/index.php
+++ b/public_html/ec/index.php
@@ -472,8 +472,8 @@ function getPageTemplate( $type ){
                         <tr><td>{#import#}:</td><td><span class="tdgeneral">{$import_iw} <small>x</small></span></td></tr>
                         <tr><td colspan=2></td></tr>
                         <tr><td colspan=2></td></tr>
-                <!--    <tr><td style="color:gray">罪恶:</td></td></tr> -->
-                        <tr><td style="color:gray">过错:</td></td></tr>
+                <!--    <tr><td style="color:gray">{#mainspace#}:</td></td></tr> -->
+                        <tr><td style="color:gray">{#mainspace#}:</td></td></tr>
                         <tr><td>(Re)blocked:</td><td><span class="tdgeneral"><a href="//{$domain}/w/index.php?title=Special%3ALog&type=block&user=&page=User%3A{$usernameurl}&year=&month=-1&tagfilter=" >{$blockednum} <small>x</small></a></span></td></tr>
                         <tr><td colspan=2 >Longest block:&nbsp;<span style="float:right" >{$blockedlongest}</span></td></tr>
                         <tr><td colspan=2 >{$blockedcurrent}</td></tr>


### PR DESCRIPTION
Fixes #72 
- Fix hard-coded mainspace message when {#mainspace#} was intended.
- Fetch the namespaces from meta via https, not http.
- Increment the redis cache key suffix so that invalid cache contents are
  discarded.
