### PR TITLE
Add 'http:' back to url stripping patterns

### DIFF
--- a/modules/WebTool.php
+++ b/modules/WebTool.php
@@ -256,7 +256,7 @@ class WebTool {
       }
       
       $combo = ( $project ) ? $project : $lang.$wiki;
-      $combo = str_replace( array('https:', 'https:', '//', '/', '.', 'org'), array('','','','','',''), $combo );
+      $combo = str_replace( array('http:', 'https:', '//', '/', '.', 'org'), array('','','','','',''), $combo );
       
       if ( preg_match( '/(?:wiki$|wikipedia)/', $combo , $matches ) ){
            #$perflog->stack[] = $matches;


### PR DESCRIPTION
Various permalinks and links from other tools and databases pass it 'http' urls.

Follows-up 6941d7121dd.
