### PR TITLE
Renaming #wikimedia-labs to #wikimedia-cloud

### DIFF
--- a/public_html/templates/main.php
+++ b/public_html/templates/main.php
@@ -78,8 +78,8 @@
                 <a href="//en.wikipedia.org/wiki/User:X!">X!</a> &bull;  
 				<?php echo $wt->sourcecode ?>
 				<?php echo $wt->bugreport ?>
-				<a href="irc://irc.freenode.net/#wikimedia-labs" >#wikimedia-labs</a>
-				<sup><a  style="color:green" href="https://webchat.freenode.net/?channels=#wikimedia-labs">WebChat</a></sup>
+				<a href="irc://irc.freenode.net/#wikimedia-cloud" >#wikimedia-cloud</a>
+				<sup><a  style="color:green" href="https://webchat.freenode.net/?channels=#wikimedia-cloud">WebChat</a></sup>
 			</span>
 			<br />
 			<span><?php echo $wt->langLinks ?></span>


### PR DESCRIPTION
The IRC channel has been renamed as "Labs" is being deprecated in favor of "Wikimedia Cloud Services". Although the -labs channel forwards to the -cloud one, some users may experience issues because their IRC clients might not support forwarding or have blocked channel forwarding.